### PR TITLE
fix link broken when rendered under https://docs.flutter.io

### DIFF
--- a/dev/docs/README.md
+++ b/dev/docs/README.md
@@ -8,4 +8,4 @@ source.
 * **Main site: [flutter.io](https://flutter.io/)**
 * [Install](https://flutter.io/setup/)
 * [Get started](https://flutter.io/getting-started/)
-* [Contribute](CONTRIBUTING.md)
+* [Contribute](https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
fixes #18943